### PR TITLE
[AUTH] Refresh Token 갱신 로직 구현 (#12)

### DIFF
--- a/src/main/java/com/fitlog/fitlogv2server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/auth/controller/AuthController.java
@@ -1,0 +1,52 @@
+package com.fitlog.fitlogv2server.domain.auth.controller;
+
+import com.fitlog.fitlogv2server.domain.member.entity.Member;
+import com.fitlog.fitlogv2server.domain.member.repository.MemberRepository;
+import com.fitlog.fitlogv2server.global.security.token.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final TokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(@RequestBody Map<String, String> body) {
+        String refreshToken = body.get("refreshToken");
+
+        if (refreshToken == null || !tokenProvider.validateToken(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid refresh token");
+        }
+
+        Member member = memberRepository.findByRefreshToken(refreshToken)
+                .orElse(null);
+
+        if (member == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Refresh token not found");
+        }
+
+        String newAccessToken = tokenProvider.createAccessToken(
+                member.getId(), member.getEmail(), member.getNickname(), member.getRole());
+        String newRefreshToken = tokenProvider.createRefreshToken(
+                member.getId(), member.getEmail(), member.getNickname(), member.getRole());
+
+        member.updateRefreshToken(newRefreshToken);
+        memberRepository.save(member);
+
+        return ResponseEntity.ok(Map.of(
+                "accessToken", newAccessToken,
+                "refreshToken", newRefreshToken
+        ));
+    }
+}

--- a/src/main/java/com/fitlog/fitlogv2server/domain/member/entity/Member.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/member/entity/Member.java
@@ -48,6 +48,9 @@ public class Member extends BaseTimeEntity {
 
     private String experience;
 
+    @Column(length = 512)
+    private String refreshToken;
+
     @Builder
     public Member(String email, String nickname, String imageUrl, Role role, Provider provider, String providerId,
                   String phone, String birthDate, Integer height, Integer weight, String goal, String experience) {
@@ -71,6 +74,10 @@ public class Member extends BaseTimeEntity {
 
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
     public void updateProfile(String nickname, String phone, String birthDate,

--- a/src/main/java/com/fitlog/fitlogv2server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/member/repository/MemberRepository.java
@@ -14,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      * 이미 가입된 사용자인지 확인하기 위한 메서드입니다.
      */
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/fitlog/fitlogv2server/global/config/SecurityConfig.java
+++ b/src/main/java/com/fitlog/fitlogv2server/global/config/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll() // CORS Preflight 요청 허용
                         // /api/members/me 같은 인증 필요한 API
-                        .requestMatchers("/api/members/**", "/api/workout/**", "/api/workout-programs/**", "/api/workoutroutine/**", "/api/workout-sessions/**", "/api/dashboard/**").authenticated() // [수정] 인증 필요 경로 명시
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/members/**", "/api/workout/**", "/api/workout-programs/**", "/api/workoutroutine/**", "/api/workout-sessions/**", "/api/dashboard/**").authenticated()
                         // 그 외 모든 요청(로그인, 루트 등) 허용
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/com/fitlog/fitlogv2server/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/fitlog/fitlogv2server/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -54,9 +54,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String accessToken = tokenProvider.createAccessToken(member.getId(), email, member.getNickname(), member.getRole());
         String refreshToken = tokenProvider.createRefreshToken(member.getId(), email, member.getNickname(), member.getRole());
 
-        // [!] (중요) Refresh Token은 DB에 저장해야 함 (지금은 생략, 추후 구현)
-        // member.updateRefreshToken(refreshToken);
-        // memberRepository.save(member);
+        member.updateRefreshToken(refreshToken);
+        memberRepository.save(member);
 
         // 6. 프론트엔드(Vue)로 리다이렉트 (토큰을 쿼리 파라미터로 전달)
         String targetUrl = UriComponentsBuilder.fromUriString(clientUrl + "/auth/callback") // 프론트의 콜백 URL


### PR DESCRIPTION
## 개요
accessToken 만료 후 자동 갱신 없이 강제 로그아웃되는 문제 해결

Closes #12

## 변경 사항
- `Member` 엔티티에 `refreshToken` 컬럼 추가 + `updateRefreshToken()` 메서드
- `MemberRepository`에 `findByRefreshToken()` 추가
- `AuthController` 신규: `POST /api/auth/refresh`
  - refreshToken 서명 검증 및 DB 대조 (탈취 방지)
  - 새 accessToken + refreshToken 발급 및 DB rotation
- `OAuth2LoginSuccessHandler`: 로그인 시 refreshToken DB 저장
- `SecurityConfig`: `/api/auth/**` permitAll 추가