### PR TITLE
운동 세션 진행 중 세트 추가 API 구현

### DIFF
--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/controller/WorkoutSessionController.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/controller/WorkoutSessionController.java
@@ -135,4 +135,14 @@ public class WorkoutSessionController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/{sessionId}/exercises/{workoutSessionExerciseId}/sets")
+    public ResponseEntity<WorkoutSessionDto.Response> addSet(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long sessionId,
+            @PathVariable Long workoutSessionExerciseId,
+            @RequestBody WorkoutSessionDto.CreateSetRequest request) {
+        WorkoutSessionDto.Response response = workoutSessionFacade.addSet(userDetails.getId(), sessionId, workoutSessionExerciseId, request);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/dto/WorkoutSessionDto.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/dto/WorkoutSessionDto.java
@@ -98,6 +98,14 @@ public class WorkoutSessionDto {
     }
 
     @Getter
+    public static class CreateSetRequest {
+        private Double weight;
+        private Integer reps;
+        private Integer restTime;
+        private String memo;
+    }
+
+    @Getter
     public static class Response {
         private Long id;
         private Long workoutProgramId;

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/facade/WorkoutSessionFacade.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/facade/WorkoutSessionFacade.java
@@ -120,4 +120,10 @@ public class WorkoutSessionFacade {
         WorkoutSession workoutSession = workoutSessionService.startExercise(memberId, sessionId, exerciseId, request.getStartedAt());
         return new WorkoutSessionDto.Response(workoutSession);
     }
+
+    @Transactional
+    public WorkoutSessionDto.Response addSet(Long memberId, Long sessionId, Long workoutSessionExerciseId, WorkoutSessionDto.CreateSetRequest request) {
+        WorkoutSession workoutSession = workoutSessionService.addSet(memberId, sessionId, workoutSessionExerciseId, request);
+        return new WorkoutSessionDto.Response(workoutSession);
+    }
 }

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionService.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionService.java
@@ -362,6 +362,65 @@ public class WorkoutSessionService {
         return workoutSession;
     }
 
+    @Transactional
+    public WorkoutSession addSet(Long memberId, Long sessionId, Long workoutSessionExerciseId, WorkoutSessionDto.CreateSetRequest request) {
+        WorkoutSession workoutSession = workoutSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("Workout session not found"));
+
+        if (!workoutSession.getMember().getId().equals(memberId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+        }
+
+        if (workoutSession.getStatus() != SessionStatus.IN_PROGRESS) {
+            throw new IllegalStateException("진행 중인 세션에서만 세트를 추가할 수 있습니다.");
+        }
+
+        if (request.getReps() == null) {
+            throw new IllegalArgumentException("reps는 필수입니다.");
+        }
+        if (request.getReps() <= 0) {
+            throw new IllegalArgumentException("reps는 1 이상이어야 합니다.");
+        }
+        if (request.getRestTime() == null) {
+            throw new IllegalArgumentException("restTime은 필수입니다.");
+        }
+        if (request.getRestTime() < 0) {
+            throw new IllegalArgumentException("restTime은 0 이상이어야 합니다.");
+        }
+        if (request.getWeight() != null && request.getWeight() < 0) {
+            throw new IllegalArgumentException("weight는 0 이상이어야 합니다.");
+        }
+
+        WorkoutSessionExercise exercise = workoutSession.getWorkoutSessionExercises().stream()
+                .filter(e -> e.getId().equals(workoutSessionExerciseId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Workout session exercise not found in this session"));
+
+        int nextSetNumber = exercise.getWorkoutSessionSets().stream()
+                .mapToInt(WorkoutSessionSet::getSetNumber)
+                .max()
+                .orElse(0) + 1;
+
+        WorkoutSessionSet newSet = WorkoutSessionSet.builder()
+                .workoutSessionExercise(exercise)
+                .setNumber(nextSetNumber)
+                .weight(request.getWeight())
+                .reps(request.getReps())
+                .restTime(request.getRestTime())
+                .memo(request.getMemo())
+                .completed(false)
+                .actualWeight(null)
+                .actualReps(null)
+                .actualMemo(null)
+                .completedAt(null)
+                .build();
+
+        workoutSessionSetRepository.save(newSet);
+        exercise.addWorkoutSessionSet(newSet);
+
+        return workoutSession;
+    }
+
     private WorkoutSession findWorkoutSessionByIdAndMemberId(Long sessionId, Long memberId) {
         return workoutSessionRepository.findByIdAndMemberId(sessionId, memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Workout session not found or does not belong to the member"));

--- a/src/test/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionServiceTest.java
+++ b/src/test/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionServiceTest.java
@@ -1,0 +1,211 @@
+package com.fitlog.fitlogv2server.domain.workoutsession.service;
+
+import com.fitlog.fitlogv2server.domain.member.entity.Member;
+import com.fitlog.fitlogv2server.domain.workout.repository.WorkoutRepository;
+import com.fitlog.fitlogv2server.domain.workoutprogram.repository.WorkoutProgramRepository;
+import com.fitlog.fitlogv2server.domain.workoutsession.dto.WorkoutSessionDto;
+import com.fitlog.fitlogv2server.domain.workoutsession.entity.SessionStatus;
+import com.fitlog.fitlogv2server.domain.workoutsession.entity.WorkoutSession;
+import com.fitlog.fitlogv2server.domain.workoutsession.entity.WorkoutSessionExercise;
+import com.fitlog.fitlogv2server.domain.workoutsession.entity.WorkoutSessionSet;
+import com.fitlog.fitlogv2server.domain.workoutsession.repository.WorkoutSessionExerciseRepository;
+import com.fitlog.fitlogv2server.domain.workoutsession.repository.WorkoutSessionRepository;
+import com.fitlog.fitlogv2server.domain.workoutsession.repository.WorkoutSessionSetRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class WorkoutSessionServiceTest {
+
+    @Mock
+    private WorkoutSessionRepository workoutSessionRepository;
+    @Mock
+    private WorkoutProgramRepository workoutProgramRepository;
+    @Mock
+    private WorkoutSessionExerciseRepository workoutSessionExerciseRepository;
+    @Mock
+    private WorkoutSessionSetRepository workoutSessionSetRepository;
+    @Mock
+    private WorkoutRepository workoutRepository;
+
+    @InjectMocks
+    private WorkoutSessionService workoutSessionService;
+
+    private static final Long MEMBER_ID = 10L;
+    private static final Long SESSION_ID = 1L;
+    private static final Long EXERCISE_ID = 100L;
+
+    @Test
+    void addSet_appendsSetToEndWithSequentialSetNumber() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1, 2);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+        given(workoutSessionSetRepository.save(any(WorkoutSessionSet.class))).willAnswer(inv -> inv.getArgument(0));
+
+        WorkoutSession result = workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, "메모"));
+
+        ArgumentCaptor<WorkoutSessionSet> captor = ArgumentCaptor.forClass(WorkoutSessionSet.class);
+        verify(workoutSessionSetRepository).save(captor.capture());
+        WorkoutSessionSet saved = captor.getValue();
+        assertThat(saved.getSetNumber()).isEqualTo(3);
+        assertThat(saved.getWeight()).isEqualTo(60.0);
+        assertThat(saved.getReps()).isEqualTo(10);
+        assertThat(saved.getRestTime()).isEqualTo(60);
+        assertThat(saved.getMemo()).isEqualTo("메모");
+        assertThat(saved.getCompleted()).isFalse();
+        assertThat(saved.getActualWeight()).isNull();
+        assertThat(saved.getActualReps()).isNull();
+        assertThat(saved.getActualMemo()).isNull();
+        assertThat(saved.getCompletedAt()).isNull();
+
+        WorkoutSessionExercise exercise = result.getWorkoutSessionExercises().iterator().next();
+        assertThat(exercise.getWorkoutSessionSets()).hasSize(3);
+        assertThat(exercise.getWorkoutSessionSets())
+                .anyMatch(s -> s.getSetNumber() == 3 && Boolean.FALSE.equals(s.getCompleted()));
+    }
+
+    @Test
+    void addSet_startsAtSetNumberOneWhenNoExistingSets() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+        given(workoutSessionSetRepository.save(any(WorkoutSessionSet.class))).willAnswer(inv -> inv.getArgument(0));
+
+        workoutSessionService.addSet(MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(null, 8, 90, null));
+
+        ArgumentCaptor<WorkoutSessionSet> captor = ArgumentCaptor.forClass(WorkoutSessionSet.class);
+        verify(workoutSessionSetRepository).save(captor.capture());
+        assertThat(captor.getValue().getSetNumber()).isEqualTo(1);
+        assertThat(captor.getValue().getWeight()).isNull();
+    }
+
+    @Test
+    void addSet_rejectsWhenSessionNotInProgress() {
+        for (SessionStatus status : List.of(SessionStatus.COMPLETED, SessionStatus.PAUSED, SessionStatus.CANCELLED)) {
+            WorkoutSession session = buildSession(status, 1);
+            given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+            assertThatThrownBy(() -> workoutSessionService.addSet(
+                    MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, null)))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+        verify(workoutSessionSetRepository, never()).save(any());
+    }
+
+    @Test
+    void addSet_rejectsWhenSessionBelongsToAnotherMember() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> workoutSessionService.addSet(
+                999L, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, null)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
+        verify(workoutSessionSetRepository, never()).save(any());
+    }
+
+    @Test
+    void addSet_rejectsWhenSessionNotFound() {
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, null)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void addSet_rejectsWhenExerciseNotInSession() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, 999L, buildRequest(60.0, 10, 60, null)))
+                .isInstanceOf(IllegalArgumentException.class);
+        verify(workoutSessionSetRepository, never()).save(any());
+    }
+
+    @Test
+    void addSet_rejectsWhenRepsMissing() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, null, 60, null)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void addSet_rejectsWhenRestTimeMissing() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, null, null)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private WorkoutSession buildSession(SessionStatus status, int... existingSetNumbers) {
+        Member member = Member.builder()
+                .email("user@example.com")
+                .nickname("user")
+                .build();
+        ReflectionTestUtils.setField(member, "id", MEMBER_ID);
+
+        WorkoutSession session = WorkoutSession.builder()
+                .member(member)
+                .startTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .status(status)
+                .build();
+        ReflectionTestUtils.setField(session, "id", SESSION_ID);
+
+        WorkoutSessionExercise exercise = WorkoutSessionExercise.builder()
+                .workoutSession(session)
+                .order(1)
+                .build();
+        ReflectionTestUtils.setField(exercise, "id", EXERCISE_ID);
+
+        long setId = 1000L;
+        for (int setNumber : existingSetNumbers) {
+            WorkoutSessionSet set = WorkoutSessionSet.builder()
+                    .workoutSessionExercise(exercise)
+                    .setNumber(setNumber)
+                    .weight(50.0)
+                    .reps(10)
+                    .restTime(60)
+                    .completed(true)
+                    .build();
+            ReflectionTestUtils.setField(set, "id", setId++);
+            exercise.addWorkoutSessionSet(set);
+        }
+
+        session.addWorkoutSessionExercise(exercise);
+        return session;
+    }
+
+    private WorkoutSessionDto.CreateSetRequest buildRequest(Double weight, Integer reps, Integer restTime, String memo) {
+        WorkoutSessionDto.CreateSetRequest request = new WorkoutSessionDto.CreateSetRequest();
+        ReflectionTestUtils.setField(request, "weight", weight);
+        ReflectionTestUtils.setField(request, "reps", reps);
+        ReflectionTestUtils.setField(request, "restTime", restTime);
+        ReflectionTestUtils.setField(request, "memo", memo);
+        return request;
+    }
+}


### PR DESCRIPTION
POST /api/workout-sessions/{sessionId}/exercises/{workoutSessionExerciseId}/sets
엔드포인트를 추가하여 IN_PROGRESS 세션의 운동 항목 끝에 세트를 즉석에서
추가할 수 있도록 한다. setNumber는 서버에서 순차 생성하며 갱신된 전체
세션을 반환한다.

https://claude.ai/code/session_01N3zEya19qAzUMUsipmYJES