### PR TITLE
글로벌 서비스를 위한 시간대 처리 UTC 일원화

### DIFF
--- a/src/main/java/com/fitlog/fitlogv2server/FitlogV2ServerApplication.java
+++ b/src/main/java/com/fitlog/fitlogv2server/FitlogV2ServerApplication.java
@@ -1,12 +1,24 @@
 package com.fitlog.fitlogv2server;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableJpaAuditing
 public class FitlogV2ServerApplication {
+
+    /**
+     * 서버가 어느 지역에서 실행되든 모든 시각을 UTC 기준으로 저장하도록
+     * JVM 기본 시간대를 UTC로 고정한다. (JPA Auditing의 createdAt/updatedAt 포함)
+     */
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(FitlogV2ServerApplication.class, args);

--- a/src/main/java/com/fitlog/fitlogv2server/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/dashboard/controller/DashboardController.java
@@ -2,12 +2,14 @@ package com.fitlog.fitlogv2server.domain.dashboard.controller;
 
 import com.fitlog.fitlogv2server.domain.dashboard.dto.DashboardStatsDto;
 import com.fitlog.fitlogv2server.domain.dashboard.service.DashboardService;
+import com.fitlog.fitlogv2server.global.common.AppTimeZone;
 import com.fitlog.fitlogv2server.global.security.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,7 +21,9 @@ public class DashboardController {
 
     @GetMapping("/stats")
     public ResponseEntity<DashboardStatsDto> getStats(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        return ResponseEntity.ok(dashboardService.getStats(userDetails.getId()));
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) String timeZone) {
+        return ResponseEntity.ok(
+                dashboardService.getStats(userDetails.getId(), AppTimeZone.resolveOrUtc(timeZone)));
     }
 }

--- a/src/main/java/com/fitlog/fitlogv2server/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/dashboard/service/DashboardService.java
@@ -29,8 +29,7 @@ public class DashboardService {
 
     private final WorkoutSessionRepository workoutSessionRepository;
 
-    public DashboardStatsDto getStats(Long memberId) {
-        ZoneId zone = ZoneId.systemDefault();
+    public DashboardStatsDto getStats(Long memberId, ZoneId zone) {
         LocalDate today = LocalDate.now(zone);
 
         LocalDate weekStart = today.with(DayOfWeek.MONDAY);

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/controller/WorkoutSessionController.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/controller/WorkoutSessionController.java
@@ -2,6 +2,7 @@ package com.fitlog.fitlogv2server.domain.workoutsession.controller;
 
 import com.fitlog.fitlogv2server.domain.workoutsession.dto.WorkoutSessionDto;
 import com.fitlog.fitlogv2server.domain.workoutsession.facade.WorkoutSessionFacade;
+import com.fitlog.fitlogv2server.global.common.AppTimeZone;
 import com.fitlog.fitlogv2server.global.security.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -112,8 +113,10 @@ public class WorkoutSessionController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 10, sort = "startTime", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
-        WorkoutSessionDto.LogPageResponse response = workoutSessionFacade.getWorkoutLog(userDetails.getId(), pageable, startDate, endDate);
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) String timeZone) {
+        WorkoutSessionDto.LogPageResponse response = workoutSessionFacade.getWorkoutLog(
+                userDetails.getId(), pageable, startDate, endDate, AppTimeZone.resolveOrUtc(timeZone));
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/entity/WorkoutSessionSet.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/entity/WorkoutSessionSet.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 @Entity
@@ -52,6 +53,6 @@ public class WorkoutSessionSet {
         this.actualReps = actualReps;
         this.actualMemo = actualMemo;
         this.completed = true;
-        this.completedAt = ZonedDateTime.now();
+        this.completedAt = ZonedDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/facade/WorkoutSessionFacade.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/facade/WorkoutSessionFacade.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
@@ -84,15 +84,16 @@ public class WorkoutSessionFacade {
     }
 
     @Transactional(readOnly = true)
-    public WorkoutSessionDto.LogPageResponse getWorkoutLog(Long memberId, Pageable pageable, LocalDate startDate, LocalDate endDate) {
+    public WorkoutSessionDto.LogPageResponse getWorkoutLog(Long memberId, Pageable pageable, LocalDate startDate, LocalDate endDate, ZoneId zoneId) {
         Page<WorkoutSessionDto.LogSummaryResponse> page;
         long totalDurationSeconds;
         long totalCompletedSets;
         long totalSets;
 
         if (startDate != null && endDate != null) {
-            ZonedDateTime start = startDate.atStartOfDay(ZoneOffset.UTC);
-            ZonedDateTime end = endDate.plusDays(1).atStartOfDay(ZoneOffset.UTC);
+            // 사용자의 시간대 기준 하루 경계를 UTC 인스턴트로 변환해 필터링한다.
+            ZonedDateTime start = startDate.atStartOfDay(zoneId);
+            ZonedDateTime end = endDate.plusDays(1).atStartOfDay(zoneId);
             page = workoutSessionService.getCompletedSessions(memberId, pageable, start, end)
                     .map(WorkoutSessionDto.LogSummaryResponse::new);
             totalDurationSeconds = workoutSessionService.sumDurationSeconds(memberId, start, end);

--- a/src/main/java/com/fitlog/fitlogv2server/global/common/AppTimeZone.java
+++ b/src/main/java/com/fitlog/fitlogv2server/global/common/AppTimeZone.java
@@ -1,0 +1,35 @@
+package com.fitlog.fitlogv2server.global.common;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+/**
+ * 시간대 처리 정책.
+ * <p>
+ * 모든 시각 데이터는 UTC로 저장하고, 사용자에게 표시하거나 날짜 단위로 조회할 때만
+ * 클라이언트(사용자)의 시간대로 변환한다. 글로벌 서비스를 위해 서버의 로컬 시간대에
+ * 의존하지 않는다.
+ */
+public final class AppTimeZone {
+
+    /** 저장 기준 시간대. 모든 타임스탬프는 UTC로 보관한다. */
+    public static final ZoneId STORAGE_ZONE = ZoneOffset.UTC;
+
+    private AppTimeZone() {
+    }
+
+    /**
+     * 클라이언트가 전달한 IANA 시간대 문자열(예: "Asia/Seoul")을 안전하게 {@link ZoneId}로 변환한다.
+     * 값이 없거나 유효하지 않으면 UTC로 처리한다.
+     */
+    public static ZoneId resolveOrUtc(String zoneId) {
+        if (zoneId == null || zoneId.isBlank()) {
+            return ZoneOffset.UTC;
+        }
+        try {
+            return ZoneId.of(zoneId.trim());
+        } catch (Exception e) {
+            return ZoneOffset.UTC;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,16 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC # 모든 타임스탬프를 UTC 기준으로 저장/조회
+
+  # --- 직렬화 설정: 시각은 UTC ISO-8601(offset 포함)로 응답, 클라이언트가 로컬 시간대로 변환 ---
+  jackson:
+    time-zone: UTC
+    serialization:
+      write-dates-as-timestamps: false
 
   security:
     oauth2:


### PR DESCRIPTION
## 배경

운동 프로그램을 시작할 때 `workout_session`에 저장되는 값에서 `createdAt`은 한국시간으로, `startTime`/`endTime`은 그보다 9시간 이전(UTC)으로 저장되는 불일치가 있었습니다.

원인은 저장 시간대가 섞여 있었기 때문입니다.
- 세션 `startTime`/`endTime` → `ZonedDateTime.now(UTC)` (UTC)
- `createdAt`/`updatedAt`(JPA Auditing), 세트 `completedAt` → 서버 로컬 시간대(KST)

글로벌 서비스를 염두에 두고, **저장은 항상 UTC로 통일**하고 **표시·날짜 조회 시에만 클라이언트 시간대로 변환**하도록 정리했습니다.

## 변경 내용

### 저장 계층 — 모두 UTC
- JVM 기본 시간대를 UTC로 고정 (`FitlogV2ServerApplication`) → Auditing `createdAt`/`updatedAt` 포함 UTC 저장
- `hibernate.jdbc.time_zone=UTC` 로 타임스탬프 저장/조회 정규화
- 응답 직렬화를 UTC ISO-8601(offset 포함)로 설정 (Jackson)
- `WorkoutSessionSet.completedAt` 을 UTC로 저장

### 조회/표시 계층 — 클라이언트 시간대
- 시간대 유틸 `AppTimeZone` 추가 (IANA 문자열 → `ZoneId`, 유효하지 않거나 없으면 UTC)
- 운동 로그 날짜 필터(`GET /api/workout-sessions/logs`)에 선택적 `timeZone` 파라미터 추가
- 대시보드 통계(`GET /api/dashboard/stats`)에 선택적 `timeZone` 파라미터 추가 (서버 로컬 시간대 의존 제거)

두 파라미터 모두 선택적이라 기존 호출은 UTC 기준으로 동작(비파괴적)하며, 프론트가 `?timeZone=Asia/Seoul` 을 전달하면 사용자 로컬 기준으로 계산됩니다.

## API 영향
- 응답의 모든 시각이 UTC ISO-8601(offset 포함)으로 내려갑니다. 예: `"startTime": "2026-07-02T01:30:00Z"` → 프론트에서 로컬 시간대로 변환 필요
- 날짜별 조회/대시보드 호출 시 사용자 IANA 시간대를 `timeZone` 쿼리 파라미터로 전달 권장

## 확인 사항 (후속)
- **기존 데이터 미보정**: 이번 변경 이전에 저장된 `createdAt`/`completedAt`은 과거 KST 벽시계 값이라 UTC보다 9시간 빠릅니다. 정합성이 필요하면 별도 보정 마이그레이션이 필요합니다.
- 요청마다 `timeZone`을 받는 방식입니다. 서버 푸시/배치 등 요청 없는 상황에서 사용자 시간대가 필요하면 회원 프로필에 시간대 컬럼 추가를 고려해야 합니다.

## 검증
- `compileJava` / `compileTestJava` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMiFkXacnCgqJ4gwwW8fY7)_