### PR TITLE
운동 세션 진행 중 세트 추가 API 구현 (#18)

### DIFF
--- a/src/main/java/com/fitlog/fitlogv2server/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/dashboard/service/DashboardService.java
@@ -6,6 +6,7 @@ import com.fitlog.fitlogv2server.domain.workoutsession.repository.MonthlyStatPro
 import com.fitlog.fitlogv2server.domain.workoutsession.repository.RecentWorkoutProjection;
 import com.fitlog.fitlogv2server.domain.workoutsession.repository.WeeklyProgressProjection;
 import com.fitlog.fitlogv2server.domain.workoutsession.repository.WorkoutSessionRepository;
+import com.fitlog.fitlogv2server.global.common.AppTimeZone;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +31,7 @@ public class DashboardService {
     private final WorkoutSessionRepository workoutSessionRepository;
 
     public DashboardStatsDto getStats(Long memberId) {
-        ZoneId zone = ZoneId.systemDefault();
+        ZoneId zone = AppTimeZone.KST;
         LocalDate today = LocalDate.now(zone);
 
         LocalDate weekStart = today.with(DayOfWeek.MONDAY);

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/controller/WorkoutSessionController.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/controller/WorkoutSessionController.java
@@ -135,4 +135,14 @@ public class WorkoutSessionController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/{sessionId}/exercises/{workoutSessionExerciseId}/sets")
+    public ResponseEntity<WorkoutSessionDto.Response> addSet(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long sessionId,
+            @PathVariable Long workoutSessionExerciseId,
+            @RequestBody WorkoutSessionDto.CreateSetRequest request) {
+        WorkoutSessionDto.Response response = workoutSessionFacade.addSet(userDetails.getId(), sessionId, workoutSessionExerciseId, request);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/dto/WorkoutSessionDto.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/dto/WorkoutSessionDto.java
@@ -98,6 +98,14 @@ public class WorkoutSessionDto {
     }
 
     @Getter
+    public static class CreateSetRequest {
+        private Double weight;
+        private Integer reps;
+        private Integer restTime;
+        private String memo;
+    }
+
+    @Getter
     public static class Response {
         private Long id;
         private Long workoutProgramId;

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/entity/WorkoutSessionSet.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/entity/WorkoutSessionSet.java
@@ -1,5 +1,6 @@
 package com.fitlog.fitlogv2server.domain.workoutsession.entity;
 
+import com.fitlog.fitlogv2server.global.common.AppTimeZone;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -52,6 +53,6 @@ public class WorkoutSessionSet {
         this.actualReps = actualReps;
         this.actualMemo = actualMemo;
         this.completed = true;
-        this.completedAt = ZonedDateTime.now();
+        this.completedAt = ZonedDateTime.now(AppTimeZone.KST);
     }
 }

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/facade/WorkoutSessionFacade.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/facade/WorkoutSessionFacade.java
@@ -120,4 +120,10 @@ public class WorkoutSessionFacade {
         WorkoutSession workoutSession = workoutSessionService.startExercise(memberId, sessionId, exerciseId, request.getStartedAt());
         return new WorkoutSessionDto.Response(workoutSession);
     }
+
+    @Transactional
+    public WorkoutSessionDto.Response addSet(Long memberId, Long sessionId, Long workoutSessionExerciseId, WorkoutSessionDto.CreateSetRequest request) {
+        WorkoutSession workoutSession = workoutSessionService.addSet(memberId, sessionId, workoutSessionExerciseId, request);
+        return new WorkoutSessionDto.Response(workoutSession);
+    }
 }

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/facade/WorkoutSessionFacade.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/facade/WorkoutSessionFacade.java
@@ -11,8 +11,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fitlog.fitlogv2server.global.common.AppTimeZone;
+
 import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
@@ -91,8 +92,8 @@ public class WorkoutSessionFacade {
         long totalSets;
 
         if (startDate != null && endDate != null) {
-            ZonedDateTime start = startDate.atStartOfDay(ZoneOffset.UTC);
-            ZonedDateTime end = endDate.plusDays(1).atStartOfDay(ZoneOffset.UTC);
+            ZonedDateTime start = startDate.atStartOfDay(AppTimeZone.KST);
+            ZonedDateTime end = endDate.plusDays(1).atStartOfDay(AppTimeZone.KST);
             page = workoutSessionService.getCompletedSessions(memberId, pageable, start, end)
                     .map(WorkoutSessionDto.LogSummaryResponse::new);
             totalDurationSeconds = workoutSessionService.sumDurationSeconds(memberId, start, end);

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionService.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionService.java
@@ -267,12 +267,17 @@ public class WorkoutSessionService {
 
     @Transactional
     public WorkoutSession addExercise(Long memberId, Long sessionId, WorkoutSessionDto.AddExerciseRequest request) {
-        WorkoutSession workoutSession = findWorkoutSessionByIdAndMemberId(sessionId, memberId);
+        WorkoutSession workoutSession = findOwnedSession(sessionId, memberId);
+        validateSessionModifiable(workoutSession);
+
+        if (request.getSets() == null || request.getSets().isEmpty()) {
+            throw new IllegalArgumentException("sets는 최소 1개 이상이어야 합니다.");
+        }
 
         Workout workout = workoutRepository.findById(request.getWorkoutId())
                 .orElseThrow(() -> new IllegalArgumentException("Workout not found"));
 
-        // Shift existing exercises' order if needed
+        // Shift existing exercises' order to keep ordering consistent
         int newOrder = request.getOrder() != null ? request.getOrder() :
                 workoutSession.getWorkoutSessionExercises().size() + 1;
 
@@ -289,30 +294,22 @@ public class WorkoutSessionService {
                 .build();
         workoutSession.addWorkoutSessionExercise(sessionExercise);
 
-        if (request.getSets() != null && !request.getSets().isEmpty()) {
-            for (WorkoutSessionDto.AddSetRequest setRequest : request.getSets()) {
-                WorkoutSessionSet sessionSet = WorkoutSessionSet.builder()
-                        .workoutSessionExercise(sessionExercise)
-                        .setNumber(setRequest.getSetNumber())
-                        .weight(setRequest.getWeight())
-                        .reps(setRequest.getReps())
-                        .restTime(setRequest.getRestTime())
-                        .memo(setRequest.getMemo())
-                        .completed(false)
-                        .build();
-                sessionExercise.addWorkoutSessionSet(sessionSet);
-            }
-        } else {
-            // Default: add 1 empty set
-            WorkoutSessionSet defaultSet = WorkoutSessionSet.builder()
+        int setNumber = 1;
+        for (WorkoutSessionDto.AddSetRequest setRequest : request.getSets()) {
+            WorkoutSessionSet sessionSet = WorkoutSessionSet.builder()
                     .workoutSessionExercise(sessionExercise)
-                    .setNumber(1)
-                    .weight(0.0)
-                    .reps(0)
-                    .restTime(60)
+                    .setNumber(setNumber++)
+                    .weight(setRequest.getWeight())
+                    .reps(setRequest.getReps())
+                    .restTime(setRequest.getRestTime())
+                    .memo(setRequest.getMemo())
                     .completed(false)
+                    .actualWeight(null)
+                    .actualReps(null)
+                    .actualMemo(null)
+                    .completedAt(null)
                     .build();
-            sessionExercise.addWorkoutSessionSet(defaultSet);
+            sessionExercise.addWorkoutSessionSet(sessionSet);
         }
 
         return workoutSession;
@@ -364,16 +361,8 @@ public class WorkoutSessionService {
 
     @Transactional
     public WorkoutSession addSet(Long memberId, Long sessionId, Long workoutSessionExerciseId, WorkoutSessionDto.CreateSetRequest request) {
-        WorkoutSession workoutSession = workoutSessionRepository.findById(sessionId)
-                .orElseThrow(() -> new IllegalArgumentException("Workout session not found"));
-
-        if (!workoutSession.getMember().getId().equals(memberId)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
-        }
-
-        if (workoutSession.getStatus() != SessionStatus.IN_PROGRESS) {
-            throw new IllegalStateException("진행 중인 세션에서만 세트를 추가할 수 있습니다.");
-        }
+        WorkoutSession workoutSession = findOwnedSession(sessionId, memberId);
+        validateSessionModifiable(workoutSession);
 
         if (request.getReps() == null) {
             throw new IllegalArgumentException("reps는 필수입니다.");
@@ -394,7 +383,7 @@ public class WorkoutSessionService {
         WorkoutSessionExercise exercise = workoutSession.getWorkoutSessionExercises().stream()
                 .filter(e -> e.getId().equals(workoutSessionExerciseId))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Workout session exercise not found in this session"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Workout session exercise not found in this session"));
 
         int nextSetNumber = exercise.getWorkoutSessionSets().stream()
                 .mapToInt(WorkoutSessionSet::getSetNumber)
@@ -424,5 +413,21 @@ public class WorkoutSessionService {
     private WorkoutSession findWorkoutSessionByIdAndMemberId(Long sessionId, Long memberId) {
         return workoutSessionRepository.findByIdAndMemberId(sessionId, memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Workout session not found or does not belong to the member"));
+    }
+
+    private WorkoutSession findOwnedSession(Long sessionId, Long memberId) {
+        WorkoutSession workoutSession = workoutSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Workout session not found"));
+        if (!workoutSession.getMember().getId().equals(memberId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+        }
+        return workoutSession;
+    }
+
+    private void validateSessionModifiable(WorkoutSession workoutSession) {
+        SessionStatus status = workoutSession.getStatus();
+        if (status == SessionStatus.COMPLETED || status == SessionStatus.CANCELLED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "종료되거나 취소된 세션에는 운동/세트를 추가할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionService.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionService.java
@@ -25,7 +25,8 @@ import org.springframework.data.domain.Pageable;
 import com.fitlog.fitlogv2server.domain.workout.entity.Workout;
 import com.fitlog.fitlogv2server.domain.workout.repository.WorkoutRepository;
 
-import java.time.ZoneOffset;
+import com.fitlog.fitlogv2server.global.common.AppTimeZone;
+
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +55,7 @@ public class WorkoutSessionService {
         WorkoutSession workoutSession = WorkoutSession.builder()
                 .member(member)
                 .workoutProgram(workoutProgram)
-                .startTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .startTime(ZonedDateTime.now(AppTimeZone.KST))
                 .status(SessionStatus.IN_PROGRESS)
                 .build();
 
@@ -138,7 +139,7 @@ public class WorkoutSessionService {
         workoutSessionSet.completeSet(request.getActualWeight(), request.getActualReps(), request.getMemo());
 
         if (workoutSession.isAllSetsCompleted()) {
-            workoutSession.updateStatusAndEndTime(SessionStatus.COMPLETED, ZonedDateTime.now(ZoneOffset.UTC));
+            workoutSession.updateStatusAndEndTime(SessionStatus.COMPLETED, ZonedDateTime.now(AppTimeZone.KST));
         }
 
         return workoutSession;
@@ -150,7 +151,7 @@ public class WorkoutSessionService {
         if (workoutSession.getStatus() == SessionStatus.PAUSED) {
             throw new IllegalStateException("Workout session is already paused.");
         }
-        workoutSession.pause(ZonedDateTime.now(ZoneOffset.UTC));
+        workoutSession.pause(ZonedDateTime.now(AppTimeZone.KST));
         return workoutSession;
     }
 
@@ -160,7 +161,7 @@ public class WorkoutSessionService {
         if (workoutSession.getStatus() == SessionStatus.IN_PROGRESS) {
             throw new IllegalStateException("Workout session is already in progress.");
         }
-        workoutSession.resume(ZonedDateTime.now(ZoneOffset.UTC));
+        workoutSession.resume(ZonedDateTime.now(AppTimeZone.KST));
         return workoutSession;
     }
 
@@ -239,7 +240,7 @@ public class WorkoutSessionService {
         }
 
         if (workoutSession.isAllSetsCompleted()) {
-            workoutSession.updateStatusAndEndTime(SessionStatus.COMPLETED, ZonedDateTime.now(ZoneOffset.UTC));
+            workoutSession.updateStatusAndEndTime(SessionStatus.COMPLETED, ZonedDateTime.now(AppTimeZone.KST));
         }
 
         return workoutSession;

--- a/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionService.java
+++ b/src/main/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionService.java
@@ -362,6 +362,65 @@ public class WorkoutSessionService {
         return workoutSession;
     }
 
+    @Transactional
+    public WorkoutSession addSet(Long memberId, Long sessionId, Long workoutSessionExerciseId, WorkoutSessionDto.CreateSetRequest request) {
+        WorkoutSession workoutSession = workoutSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("Workout session not found"));
+
+        if (!workoutSession.getMember().getId().equals(memberId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+        }
+
+        if (workoutSession.getStatus() != SessionStatus.IN_PROGRESS) {
+            throw new IllegalStateException("진행 중인 세션에서만 세트를 추가할 수 있습니다.");
+        }
+
+        if (request.getReps() == null) {
+            throw new IllegalArgumentException("reps는 필수입니다.");
+        }
+        if (request.getReps() <= 0) {
+            throw new IllegalArgumentException("reps는 1 이상이어야 합니다.");
+        }
+        if (request.getRestTime() == null) {
+            throw new IllegalArgumentException("restTime은 필수입니다.");
+        }
+        if (request.getRestTime() < 0) {
+            throw new IllegalArgumentException("restTime은 0 이상이어야 합니다.");
+        }
+        if (request.getWeight() != null && request.getWeight() < 0) {
+            throw new IllegalArgumentException("weight는 0 이상이어야 합니다.");
+        }
+
+        WorkoutSessionExercise exercise = workoutSession.getWorkoutSessionExercises().stream()
+                .filter(e -> e.getId().equals(workoutSessionExerciseId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Workout session exercise not found in this session"));
+
+        int nextSetNumber = exercise.getWorkoutSessionSets().stream()
+                .mapToInt(WorkoutSessionSet::getSetNumber)
+                .max()
+                .orElse(0) + 1;
+
+        WorkoutSessionSet newSet = WorkoutSessionSet.builder()
+                .workoutSessionExercise(exercise)
+                .setNumber(nextSetNumber)
+                .weight(request.getWeight())
+                .reps(request.getReps())
+                .restTime(request.getRestTime())
+                .memo(request.getMemo())
+                .completed(false)
+                .actualWeight(null)
+                .actualReps(null)
+                .actualMemo(null)
+                .completedAt(null)
+                .build();
+
+        workoutSessionSetRepository.save(newSet);
+        exercise.addWorkoutSessionSet(newSet);
+
+        return workoutSession;
+    }
+
     private WorkoutSession findWorkoutSessionByIdAndMemberId(Long sessionId, Long memberId) {
         return workoutSessionRepository.findByIdAndMemberId(sessionId, memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Workout session not found or does not belong to the member"));

--- a/src/main/java/com/fitlog/fitlogv2server/global/common/AppTimeZone.java
+++ b/src/main/java/com/fitlog/fitlogv2server/global/common/AppTimeZone.java
@@ -1,0 +1,15 @@
+package com.fitlog.fitlogv2server.global.common;
+
+import java.time.ZoneId;
+
+/**
+ * 애플리케이션 전역에서 사용하는 기준 시간대(KST).
+ * 세션 시각 저장(쓰기)과 대시보드 집계(읽기)가 동일한 존을 쓰도록 통일한다.
+ */
+public final class AppTimeZone {
+
+    public static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private AppTimeZone() {
+    }
+}

--- a/src/test/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionServiceTest.java
+++ b/src/test/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionServiceTest.java
@@ -1,0 +1,211 @@
+package com.fitlog.fitlogv2server.domain.workoutsession.service;
+
+import com.fitlog.fitlogv2server.domain.member.entity.Member;
+import com.fitlog.fitlogv2server.domain.workout.repository.WorkoutRepository;
+import com.fitlog.fitlogv2server.domain.workoutprogram.repository.WorkoutProgramRepository;
+import com.fitlog.fitlogv2server.domain.workoutsession.dto.WorkoutSessionDto;
+import com.fitlog.fitlogv2server.domain.workoutsession.entity.SessionStatus;
+import com.fitlog.fitlogv2server.domain.workoutsession.entity.WorkoutSession;
+import com.fitlog.fitlogv2server.domain.workoutsession.entity.WorkoutSessionExercise;
+import com.fitlog.fitlogv2server.domain.workoutsession.entity.WorkoutSessionSet;
+import com.fitlog.fitlogv2server.domain.workoutsession.repository.WorkoutSessionExerciseRepository;
+import com.fitlog.fitlogv2server.domain.workoutsession.repository.WorkoutSessionRepository;
+import com.fitlog.fitlogv2server.domain.workoutsession.repository.WorkoutSessionSetRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class WorkoutSessionServiceTest {
+
+    @Mock
+    private WorkoutSessionRepository workoutSessionRepository;
+    @Mock
+    private WorkoutProgramRepository workoutProgramRepository;
+    @Mock
+    private WorkoutSessionExerciseRepository workoutSessionExerciseRepository;
+    @Mock
+    private WorkoutSessionSetRepository workoutSessionSetRepository;
+    @Mock
+    private WorkoutRepository workoutRepository;
+
+    @InjectMocks
+    private WorkoutSessionService workoutSessionService;
+
+    private static final Long MEMBER_ID = 10L;
+    private static final Long SESSION_ID = 1L;
+    private static final Long EXERCISE_ID = 100L;
+
+    @Test
+    void addSet_appendsSetToEndWithSequentialSetNumber() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1, 2);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+        given(workoutSessionSetRepository.save(any(WorkoutSessionSet.class))).willAnswer(inv -> inv.getArgument(0));
+
+        WorkoutSession result = workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, "메모"));
+
+        ArgumentCaptor<WorkoutSessionSet> captor = ArgumentCaptor.forClass(WorkoutSessionSet.class);
+        verify(workoutSessionSetRepository).save(captor.capture());
+        WorkoutSessionSet saved = captor.getValue();
+        assertThat(saved.getSetNumber()).isEqualTo(3);
+        assertThat(saved.getWeight()).isEqualTo(60.0);
+        assertThat(saved.getReps()).isEqualTo(10);
+        assertThat(saved.getRestTime()).isEqualTo(60);
+        assertThat(saved.getMemo()).isEqualTo("메모");
+        assertThat(saved.getCompleted()).isFalse();
+        assertThat(saved.getActualWeight()).isNull();
+        assertThat(saved.getActualReps()).isNull();
+        assertThat(saved.getActualMemo()).isNull();
+        assertThat(saved.getCompletedAt()).isNull();
+
+        WorkoutSessionExercise exercise = result.getWorkoutSessionExercises().iterator().next();
+        assertThat(exercise.getWorkoutSessionSets()).hasSize(3);
+        assertThat(exercise.getWorkoutSessionSets())
+                .anyMatch(s -> s.getSetNumber() == 3 && Boolean.FALSE.equals(s.getCompleted()));
+    }
+
+    @Test
+    void addSet_startsAtSetNumberOneWhenNoExistingSets() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+        given(workoutSessionSetRepository.save(any(WorkoutSessionSet.class))).willAnswer(inv -> inv.getArgument(0));
+
+        workoutSessionService.addSet(MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(null, 8, 90, null));
+
+        ArgumentCaptor<WorkoutSessionSet> captor = ArgumentCaptor.forClass(WorkoutSessionSet.class);
+        verify(workoutSessionSetRepository).save(captor.capture());
+        assertThat(captor.getValue().getSetNumber()).isEqualTo(1);
+        assertThat(captor.getValue().getWeight()).isNull();
+    }
+
+    @Test
+    void addSet_rejectsWhenSessionNotInProgress() {
+        for (SessionStatus status : List.of(SessionStatus.COMPLETED, SessionStatus.PAUSED, SessionStatus.CANCELLED)) {
+            WorkoutSession session = buildSession(status, 1);
+            given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+            assertThatThrownBy(() -> workoutSessionService.addSet(
+                    MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, null)))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+        verify(workoutSessionSetRepository, never()).save(any());
+    }
+
+    @Test
+    void addSet_rejectsWhenSessionBelongsToAnotherMember() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> workoutSessionService.addSet(
+                999L, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, null)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
+        verify(workoutSessionSetRepository, never()).save(any());
+    }
+
+    @Test
+    void addSet_rejectsWhenSessionNotFound() {
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, null)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void addSet_rejectsWhenExerciseNotInSession() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, 999L, buildRequest(60.0, 10, 60, null)))
+                .isInstanceOf(IllegalArgumentException.class);
+        verify(workoutSessionSetRepository, never()).save(any());
+    }
+
+    @Test
+    void addSet_rejectsWhenRepsMissing() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, null, 60, null)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void addSet_rejectsWhenRestTimeMissing() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, null, null)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private WorkoutSession buildSession(SessionStatus status, int... existingSetNumbers) {
+        Member member = Member.builder()
+                .email("user@example.com")
+                .nickname("user")
+                .build();
+        ReflectionTestUtils.setField(member, "id", MEMBER_ID);
+
+        WorkoutSession session = WorkoutSession.builder()
+                .member(member)
+                .startTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .status(status)
+                .build();
+        ReflectionTestUtils.setField(session, "id", SESSION_ID);
+
+        WorkoutSessionExercise exercise = WorkoutSessionExercise.builder()
+                .workoutSession(session)
+                .order(1)
+                .build();
+        ReflectionTestUtils.setField(exercise, "id", EXERCISE_ID);
+
+        long setId = 1000L;
+        for (int setNumber : existingSetNumbers) {
+            WorkoutSessionSet set = WorkoutSessionSet.builder()
+                    .workoutSessionExercise(exercise)
+                    .setNumber(setNumber)
+                    .weight(50.0)
+                    .reps(10)
+                    .restTime(60)
+                    .completed(true)
+                    .build();
+            ReflectionTestUtils.setField(set, "id", setId++);
+            exercise.addWorkoutSessionSet(set);
+        }
+
+        session.addWorkoutSessionExercise(exercise);
+        return session;
+    }
+
+    private WorkoutSessionDto.CreateSetRequest buildRequest(Double weight, Integer reps, Integer restTime, String memo) {
+        WorkoutSessionDto.CreateSetRequest request = new WorkoutSessionDto.CreateSetRequest();
+        ReflectionTestUtils.setField(request, "weight", weight);
+        ReflectionTestUtils.setField(request, "reps", reps);
+        ReflectionTestUtils.setField(request, "restTime", restTime);
+        ReflectionTestUtils.setField(request, "memo", memo);
+        return request;
+    }
+}

--- a/src/test/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionServiceTest.java
+++ b/src/test/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionServiceTest.java
@@ -4,6 +4,7 @@ import com.fitlog.fitlogv2server.domain.member.entity.Member;
 import com.fitlog.fitlogv2server.domain.workout.entity.Workout;
 import com.fitlog.fitlogv2server.domain.workout.entity.WorkoutPart;
 import com.fitlog.fitlogv2server.domain.workout.repository.WorkoutRepository;
+import com.fitlog.fitlogv2server.domain.workoutprogram.entity.WorkoutProgram;
 import com.fitlog.fitlogv2server.domain.workoutprogram.repository.WorkoutProgramRepository;
 import com.fitlog.fitlogv2server.domain.workoutsession.dto.WorkoutSessionDto;
 import com.fitlog.fitlogv2server.domain.workoutsession.entity.SessionStatus;
@@ -13,6 +14,7 @@ import com.fitlog.fitlogv2server.domain.workoutsession.entity.WorkoutSessionSet;
 import com.fitlog.fitlogv2server.domain.workoutsession.repository.WorkoutSessionExerciseRepository;
 import com.fitlog.fitlogv2server.domain.workoutsession.repository.WorkoutSessionRepository;
 import com.fitlog.fitlogv2server.domain.workoutsession.repository.WorkoutSessionSetRepository;
+import com.fitlog.fitlogv2server.global.common.AppTimeZone;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -23,7 +25,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -31,7 +32,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -55,6 +58,30 @@ class WorkoutSessionServiceTest {
     private static final Long MEMBER_ID = 10L;
     private static final Long SESSION_ID = 1L;
     private static final Long EXERCISE_ID = 100L;
+
+    @Test
+    void startSession_recordsStartTimeInKst() {
+        Member member = Member.builder()
+                .email("user@example.com")
+                .nickname("user")
+                .build();
+        ReflectionTestUtils.setField(member, "id", MEMBER_ID);
+
+        WorkoutProgram program = mock(WorkoutProgram.class);
+        given(program.getParts()).willReturn(List.of());
+        given(workoutProgramRepository.findById(anyLong())).willReturn(Optional.of(program));
+        given(workoutSessionRepository.save(any(WorkoutSession.class))).willAnswer(inv -> inv.getArgument(0));
+
+        WorkoutSessionDto.StartRequest request = new WorkoutSessionDto.StartRequest();
+        ReflectionTestUtils.setField(request, "workoutProgramId", 1L);
+
+        WorkoutSession result = workoutSessionService.startSession(member, request);
+
+        assertThat(result.getStartTime()).isNotNull();
+        // created_at(감사, KST)과 동일하게 KST 벽시계로 저장되어야 한다 (UTC 9시간 오차 회귀 방지)
+        assertThat(result.getStartTime().getZone()).isEqualTo(AppTimeZone.KST);
+        assertThat(result.getStatus()).isEqualTo(SessionStatus.IN_PROGRESS);
+    }
 
     @Test
     void addSet_appendsSetToEndWithSequentialSetNumber() {
@@ -265,7 +292,7 @@ class WorkoutSessionServiceTest {
 
         WorkoutSession session = WorkoutSession.builder()
                 .member(member)
-                .startTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .startTime(ZonedDateTime.now(AppTimeZone.KST))
                 .status(status)
                 .build();
         ReflectionTestUtils.setField(session, "id", SESSION_ID);

--- a/src/test/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionServiceTest.java
+++ b/src/test/java/com/fitlog/fitlogv2server/domain/workoutsession/service/WorkoutSessionServiceTest.java
@@ -1,6 +1,8 @@
 package com.fitlog.fitlogv2server.domain.workoutsession.service;
 
 import com.fitlog.fitlogv2server.domain.member.entity.Member;
+import com.fitlog.fitlogv2server.domain.workout.entity.Workout;
+import com.fitlog.fitlogv2server.domain.workout.entity.WorkoutPart;
 import com.fitlog.fitlogv2server.domain.workout.repository.WorkoutRepository;
 import com.fitlog.fitlogv2server.domain.workoutprogram.repository.WorkoutProgramRepository;
 import com.fitlog.fitlogv2server.domain.workoutsession.dto.WorkoutSessionDto;
@@ -98,16 +100,32 @@ class WorkoutSessionServiceTest {
     }
 
     @Test
-    void addSet_rejectsWhenSessionNotInProgress() {
-        for (SessionStatus status : List.of(SessionStatus.COMPLETED, SessionStatus.PAUSED, SessionStatus.CANCELLED)) {
+    void addSet_rejectsWhenSessionCompletedOrCancelled() {
+        for (SessionStatus status : List.of(SessionStatus.COMPLETED, SessionStatus.CANCELLED)) {
             WorkoutSession session = buildSession(status, 1);
             given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
 
             assertThatThrownBy(() -> workoutSessionService.addSet(
                     MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, null)))
-                    .isInstanceOf(IllegalStateException.class);
+                    .isInstanceOf(ResponseStatusException.class)
+                    .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode()).isEqualTo(HttpStatus.CONFLICT));
         }
         verify(workoutSessionSetRepository, never()).save(any());
+    }
+
+    @Test
+    void addSet_allowedWhenSessionPaused() {
+        WorkoutSession session = buildSession(SessionStatus.PAUSED, 1, 2);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+        given(workoutSessionSetRepository.save(any(WorkoutSessionSet.class))).willAnswer(inv -> inv.getArgument(0));
+
+        WorkoutSession result = workoutSessionService.addSet(
+                MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, null));
+
+        ArgumentCaptor<WorkoutSessionSet> captor = ArgumentCaptor.forClass(WorkoutSessionSet.class);
+        verify(workoutSessionSetRepository).save(captor.capture());
+        assertThat(captor.getValue().getSetNumber()).isEqualTo(3);
+        assertThat(result.getStatus()).isEqualTo(SessionStatus.PAUSED);
     }
 
     @Test
@@ -128,7 +146,8 @@ class WorkoutSessionServiceTest {
 
         assertThatThrownBy(() -> workoutSessionService.addSet(
                 MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, 60, null)))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND));
     }
 
     @Test
@@ -138,7 +157,8 @@ class WorkoutSessionServiceTest {
 
         assertThatThrownBy(() -> workoutSessionService.addSet(
                 MEMBER_ID, SESSION_ID, 999L, buildRequest(60.0, 10, 60, null)))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND));
         verify(workoutSessionSetRepository, never()).save(any());
     }
 
@@ -160,6 +180,80 @@ class WorkoutSessionServiceTest {
         assertThatThrownBy(() -> workoutSessionService.addSet(
                 MEMBER_ID, SESSION_ID, EXERCISE_ID, buildRequest(60.0, 10, null, null)))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void addExercise_appendsExerciseWithRequestedSets() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+        given(workoutRepository.findById(12L)).willReturn(Optional.of(buildWorkout()));
+
+        WorkoutSessionDto.AddExerciseRequest request = buildAddExerciseRequest(12L, 2,
+                List.of(buildAddSetRequest(40.0, 10, 60, "첫 세트"), buildAddSetRequest(45.0, 8, 90, null)));
+
+        WorkoutSession result = workoutSessionService.addExercise(MEMBER_ID, SESSION_ID, request);
+
+        WorkoutSessionExercise added = result.getWorkoutSessionExercises().stream()
+                .filter(e -> e.getOrder() == 2)
+                .findFirst()
+                .orElseThrow();
+        assertThat(added.getWorkout().getId()).isEqualTo(12L);
+        assertThat(added.getSkipped()).isFalse();
+        assertThat(added.getStartedAt()).isNull();
+        assertThat(added.getWorkoutSessionSets()).hasSize(2);
+        assertThat(added.getWorkoutSessionSets())
+                .extracting(WorkoutSessionSet::getSetNumber)
+                .containsExactlyInAnyOrder(1, 2);
+        assertThat(added.getWorkoutSessionSets())
+                .allMatch(s -> Boolean.FALSE.equals(s.getCompleted())
+                        && s.getActualWeight() == null
+                        && s.getActualReps() == null
+                        && s.getActualMemo() == null
+                        && s.getCompletedAt() == null);
+    }
+
+    @Test
+    void addExercise_rejectsWhenSetsEmpty() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> workoutSessionService.addExercise(
+                MEMBER_ID, SESSION_ID, buildAddExerciseRequest(12L, 2, List.of())))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void addExercise_rejectsWhenSessionBelongsToAnotherMember() {
+        WorkoutSession session = buildSession(SessionStatus.IN_PROGRESS, 1);
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> workoutSessionService.addExercise(
+                999L, SESSION_ID, buildAddExerciseRequest(12L, 2, List.of(buildAddSetRequest(40.0, 10, 60, null)))))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
+    }
+
+    @Test
+    void addExercise_rejectsWhenSessionNotFound() {
+        given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> workoutSessionService.addExercise(
+                MEMBER_ID, SESSION_ID, buildAddExerciseRequest(12L, 2, List.of(buildAddSetRequest(40.0, 10, 60, null)))))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND));
+    }
+
+    @Test
+    void addExercise_rejectsWhenSessionCompletedOrCancelled() {
+        for (SessionStatus status : List.of(SessionStatus.COMPLETED, SessionStatus.CANCELLED)) {
+            WorkoutSession session = buildSession(status, 1);
+            given(workoutSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+            assertThatThrownBy(() -> workoutSessionService.addExercise(
+                    MEMBER_ID, SESSION_ID, buildAddExerciseRequest(12L, 2, List.of(buildAddSetRequest(40.0, 10, 60, null)))))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode()).isEqualTo(HttpStatus.CONFLICT));
+        }
     }
 
     private WorkoutSession buildSession(SessionStatus status, int... existingSetNumbers) {
@@ -207,5 +301,31 @@ class WorkoutSessionServiceTest {
         ReflectionTestUtils.setField(request, "restTime", restTime);
         ReflectionTestUtils.setField(request, "memo", memo);
         return request;
+    }
+
+    private WorkoutSessionDto.AddExerciseRequest buildAddExerciseRequest(Long workoutId, Integer order, List<WorkoutSessionDto.AddSetRequest> sets) {
+        WorkoutSessionDto.AddExerciseRequest request = new WorkoutSessionDto.AddExerciseRequest();
+        ReflectionTestUtils.setField(request, "workoutId", workoutId);
+        ReflectionTestUtils.setField(request, "order", order);
+        ReflectionTestUtils.setField(request, "sets", sets);
+        return request;
+    }
+
+    private WorkoutSessionDto.AddSetRequest buildAddSetRequest(Double weight, Integer reps, Integer restTime, String memo) {
+        WorkoutSessionDto.AddSetRequest request = new WorkoutSessionDto.AddSetRequest();
+        ReflectionTestUtils.setField(request, "setNumber", 1);
+        ReflectionTestUtils.setField(request, "weight", weight);
+        ReflectionTestUtils.setField(request, "reps", reps);
+        ReflectionTestUtils.setField(request, "restTime", restTime);
+        ReflectionTestUtils.setField(request, "memo", memo);
+        return request;
+    }
+
+    private Workout buildWorkout() {
+        WorkoutPart part = WorkoutPart.builder().name("가슴").build();
+        ReflectionTestUtils.setField(part, "id", 5L);
+        Workout workout = Workout.builder().name("벤치프레스").workoutPart(part).build();
+        ReflectionTestUtils.setField(workout, "id", 12L);
+        return workout;
     }
 }


### PR DESCRIPTION
POST /api/workout-sessions/{sessionId}/exercises/{workoutSessionExerciseId}/sets
엔드포인트를 추가하여 IN_PROGRESS 세션의 운동 항목 끝에 세트를 즉석에서
추가할 수 있도록 한다. setNumber는 서버에서 순차 생성하며 갱신된 전체
세션을 반환한다.

https://claude.ai/code/session_01N3zEya19qAzUMUsipmYJES

Co-authored-by: Claude <noreply@anthropic.com>